### PR TITLE
Remove Sports Coach and UnderHare from projects

### DIFF
--- a/projects.htm
+++ b/projects.htm
@@ -261,12 +261,6 @@
             </div>
 
             <div class="project-card">
-                <h3>Sports Coach - Perfect Your Muay Thai</h3>
-                <p>Our uniquely trained AI monitors your workout to tell you how to improve your form and deliver more
-                    power, helping you perfect your Muay Thai skills.</p>
-            </div>
-
-            <div class="project-card">
                 <h3>Scam Trainer - Protect Your Family</h3>
                 <p>Protect your family from life-altering scams and online fraud. We teach them everything they need to
                     know to stay safe from advancing AI nightmares.</p>
@@ -277,11 +271,6 @@
                 <p>A resume tailor that customizes your resume for each job opening without lying or making things up!
                     You provide your base resume(s) and supporting documents via Google Drive, and we generate a
                     customized resume for the position.</p>
-            </div>
-            <div class="project-card">
-                <h3>UnderHare - Underwear for Hairy Men</h3>
-                <p>That's right, humor, comfort, and style for men that are comfortable being hairy. Once you feel them,
-                    you'll ditch store brands!</p>
             </div>
 
         </div>


### PR DESCRIPTION
## Summary
- Removed Sports Coach (Muay Thai AI) from projects page
- Removed UnderHare (underwear brand) from projects page

## Test plan
- [ ] Verify projects.htm displays only Scam Trainer and Rez Mod

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the Sports Coach and UnderHare project cards from projects.htm, leaving only Scam Trainer and Rez Mod.
> 
> - **Website**:
>   - **Projects page (`projects.htm`)**: Remove `Sports Coach - Perfect Your Muay Thai` and `UnderHare - Underwear for Hairy Men` project cards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78d2fe644e62068585a7d41fc8b913b5a27ff361. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->