### PR TITLE
Update Vurge description with improved marketing copy

### DIFF
--- a/projects.htm
+++ b/projects.htm
@@ -261,17 +261,17 @@
             </div>
 
             <div class="project-card">
+                <h3><img src="img/vurge-logo.png" alt="Vurge Logo" style="height: 36px; margin-right: 10px; vertical-align: middle;" />Vurge - Multi-Model Hive Intelligence</h3>
+                <p>ChatGPT gives you a first draft. Vurge gives you a peer-reviewed answer where AI's top rivals, OpenAI, Anthropic, and Google, analyze your question independently and challenge
+                    each other's reasoning until they converge, or show you exactly where they don't. For professionals who need to trust AI output, when being right
+                    matters more than being fast. Try it at <a href="https://vurge.ai" style="color: #00d9c0;">vurge.ai</a></p>
+            </div>
+
+            <div class="project-card">
                 <h3><img src="img/agintico-logo.png" alt="Agintico Logo" style="height: 36px; margin-right: 10px; vertical-align: middle;" />Agintico - AI Employee Identity Platform</h3>
                 <p>Your AI agents deserve more than bot APIs. Agintico gives AI the same credentials as your human team:
                     real email accounts, Slack memberships, Office 365 access. Transform AI from external automation into
                     genuine digital employees who work alongside your people.</p>
-            </div>
-
-            <div class="project-card">
-                <h3><img src="img/vurge-logo.png" alt="Vurge Logo" style="height: 36px; margin-right: 10px; vertical-align: middle;" />Vurge - Multi-Agent AI Debate System</h3>
-                <p>Why trust one AI when three can debate? Vurge pits GPT, Claude, and Gemini against each other until
-                    they reach consensus. Smart agent dropout cuts costs by 70%. Get answers you can actually trust.
-                    Visit <a href="https://vurge.com" style="color: #00d9c0;">vurge.com</a></p>
             </div>
 
             <div class="project-card">


### PR DESCRIPTION
## Summary
- New subtitle: "Multi-Model Hive Intelligence"
- Improved description based on podcast prep materials
- Fixed domain to vurge.ai
- Moved Vurge to top of products list
- Replaced specific model names with evergreen copy: "AI's top rivals, OpenAI, Anthropic, and Google"

## Test plan
- [ ] Verify Vurge card displays correctly
- [ ] Verify vurge.ai link works

🤖 Generated with [Claude Code](https://claude.ai/code)